### PR TITLE
Fetch upstream

### DIFF
--- a/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
+++ b/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/internal/CommsReceiver.java
@@ -22,6 +22,9 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttToken;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttAck;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttInputStream;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttPubAck;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttPubComp;
+import org.eclipse.paho.client.mqttv3.internal.wire.MqttPubRec;
 import org.eclipse.paho.client.mqttv3.internal.wire.MqttWireMessage;
 import org.eclipse.paho.client.mqttv3.logging.Logger;
 import org.eclipse.paho.client.mqttv3.logging.LoggerFactory;
@@ -124,6 +127,11 @@ public class CommsReceiver implements Runnable {
 							// can occur before request processing is complete if not!
 							clientState.notifyReceivedAck((MqttAck)message);
 						}
+					} else if(message instanceof MqttPubRec || message instanceof MqttPubComp || message instanceof MqttPubAck) {
+						//This is an ack for a message we no longer have a ticket for.
+						//This probably means we already received this message and it's being send again
+						//because of timeouts, crashes, disconnects, restarts etc.
+						//It should be safe to ignore these unexpected messages.
 					} else {
 						// It its an ack and there is no token then something is not right.
 						// An ack should always have a token assoicated with it.


### PR DESCRIPTION
When the client recieves an ack for a publish is does not know about it
will disconnect and reconnect receiving the same ack again. This can only be fixed
by using clean session which is not always desirable. This patch makes sure the
client ignores the message so that the flow can continue

Signed-off-by: Hmvp <github@hmvp.nl>

Please make sure that the following boxes are checked before submitting your Pull Request, thank you!

- [ ] You have signed the [Eclipse CLA](http://www.eclipse.org/legal/CLA.php)
- [ ] All of your commits have been signed-off with the correct email address (The same one that you used to sign the CLA)
- [ ] If This PR fixes an issue, that you reference the issue below. OR if this is a new issue that you are fixing straight away that you add some Description about the bug and how this will fix it.
- [ ] If this is new functionality, You have added the appropriate Unit tests.
